### PR TITLE
Hardcode new cluster ip for woog.life

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -60,7 +60,7 @@ resource "cloudflare_record" "base_domain_a" {
   zone_id = var.zone_id
   name    = var.base_domain
   type    = "A"
-  value   = var.kubernetes_ip
+  value   = "167.233.9.17"
   proxied = var.proxy_records
 }
 


### PR DESCRIPTION
We can update the `kubernetes_ip` as soon as the api has been moved, this is just a temporary measure.

The pod is already running on the new cluster, the `Certificate` probably needs to be deleted for cert-manager to update.